### PR TITLE
Make it actually work

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,8 @@ jar {
             "Implementation-Title": "${config.mod_id}",
             "Implementation-Version": "${version}",
             "Implementation-Vendor" :"vazkii",
-            "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
+            "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
+            "MixinConfigs": "${config.mod_id}.mixins.json"
         ])
     }
 }


### PR DESCRIPTION
Without the manifest entry the Mixins are not loaded at all. The old version worked in dev because in that case the command line argument is used to specify the config.

I noticed this while analyzing heap dumps for [FerriteCore](https://github.com/malte0811/FerriteCore).